### PR TITLE
Making @SpecAssertion a repeatable annotation type

### DIFF
--- a/api/src/main/java/org/jboss/test/audit/annotations/SpecAssertion.java
+++ b/api/src/main/java/org/jboss/test/audit/annotations/SpecAssertion.java
@@ -19,10 +19,12 @@ package org.jboss.test.audit.annotations;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Documented
+@Repeatable(SpecAssertions.class)
 public @interface SpecAssertion {
 
 	public String section();
@@ -32,4 +34,3 @@ public @interface SpecAssertion {
 	public String note() default "";
 
 }
-

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <!-- ***************** -->
         <!-- Repository Deployment URLs -->
         <!-- ***************** -->


### PR DESCRIPTION
Due to the move to Java 8 it's probably a good idea to bump the version to 1.2, too.