### PR TITLE
Improvements related to section ids

### DIFF
--- a/impl/src/main/java/org/jboss/test/audit/config/PropertyKeys.java
+++ b/impl/src/main/java/org/jboss/test/audit/config/PropertyKeys.java
@@ -19,6 +19,10 @@ package org.jboss.test.audit.config;
 public final class PropertyKeys {
 
 	/**
+	 * If specified, links to the specification will be generated
+	 */
+	public static final String SPECIFICATION_BASE_URL_PROPERTY = "specification_base_url";
+	/**
 	 * If specified, links to the test class in GitHub will be generated
 	 */
 	public static final String GITHUB_BASE_URL_PROPERTY = "github_base_url";

--- a/impl/src/main/java/org/jboss/test/audit/generate/SectionsClassGenerator.java
+++ b/impl/src/main/java/org/jboss/test/audit/generate/SectionsClassGenerator.java
@@ -218,6 +218,9 @@ public class SectionsClassGenerator {
 			if (Character.isLetterOrDigit(tmpChar) || tmpChar == '_') {
 				result.append(tmpChar);
 			}
+			else if (tmpChar == '-') {
+				result.append('_');
+			}
 		}
 		return result.toString().toUpperCase();
 	}

--- a/impl/src/main/java/org/jboss/test/audit/report/CoverageReport.java
+++ b/impl/src/main/java/org/jboss/test/audit/report/CoverageReport.java
@@ -64,6 +64,7 @@ public class CoverageReport
 
    private RuntimeProperties properties;
 
+   private String specificationBaseUrl = null;
    private String fisheyeBaseUrl = null;
    private String svnBaseUrl = null;
    private String githubBaseUrl = null;
@@ -111,7 +112,10 @@ public class CoverageReport
 
       try
       {
-    	 // FishEye
+         // Specification
+         specificationBaseUrl = this.properties.getStringValue(
+               PropertyKeys.SPECIFICATION_BASE_URL_PROPERTY, null, false);
+         // FishEye
          fisheyeBaseUrl = this.properties.getStringValue(
                PropertyKeys.FISHEYE_BASE_URL_PROPERTY, null, false);
          if (fisheyeBaseUrl != null && !fisheyeBaseUrl.endsWith("/"))
@@ -821,14 +825,29 @@ public class CoverageReport
          {
             StringBuilder sb = new StringBuilder();
 
-            String originalSectionIdInfo = auditParser.hasSectionIdsGenerated() ? " <sup>["+auditParser.getSectionOriginalId(sectionId)+"]</sup>" : "";
+            StringBuilder originalSectionIdInfo = new StringBuilder();
+            if (auditParser.hasSectionIdsGenerated())
+            {
+               String originalSectionId = auditParser.getSectionOriginalId(sectionId);
+               originalSectionIdInfo.append(" <sup>[");
+               if (specificationBaseUrl != null)
+               {
+                  originalSectionIdInfo.append("<a href=\"").append(specificationBaseUrl).append("#").append(originalSectionId).append("\">");
+               }
+               originalSectionIdInfo.append(originalSectionId);
+               if (specificationBaseUrl != null)
+               {
+                  originalSectionIdInfo.append("</a>");
+               }
+               originalSectionIdInfo.append("]</sup>");
+            }
 
             // wrap each section to div element to create some "relation" between assertions and given section.
             out.write(("<div id = \"" + auditParser.getSectionTitle(sectionId) + "\">").getBytes());
 
             out.write(("<h4 class=\"sectionHeader\" id=\"" + sectionId
                   + "\">Section " + sectionId + " - "
-                  + escape(auditParser.getSectionTitle(sectionId)) + originalSectionIdInfo+ "</h4>\n")
+                  + escape(auditParser.getSectionTitle(sectionId)) + originalSectionIdInfo + "</h4>\n")
                   .getBytes());
 
             for (SectionItem item : items)

--- a/impl/src/test/java/org/jboss/test/audit/report/CoverageReportTest.java
+++ b/impl/src/test/java/org/jboss/test/audit/report/CoverageReportTest.java
@@ -39,9 +39,9 @@ public class CoverageReportTest {
 		//System.out.print(html);
 
 		assertTrue(html
-				.contains("<h4 class=\"sectionHeader\" id=\"2\">Section 2 - Concepts <sup>[concepts]</sup></h4>"));
+				.contains("<h4 class=\"sectionHeader\" id=\"2\">Section 2 - Concepts <sup>[<a href=\"https://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#concepts\">concepts</a>]</sup></h4>"));
 		assertTrue(html
-				.contains("<h4 class=\"sectionHeader\" id=\"2.2\">Section 2.2 - Bean types <sup>[bean_types]</sup></h4>"));
+				.contains("<h4 class=\"sectionHeader\" id=\"2.2\">Section 2.2 - Bean types <sup>[<a href=\"https://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#bean_types\">bean_types</a>]</sup></h4>"));
 	}
 
 	@Test

--- a/impl/src/test/resources/META-INF/test-unit.properties
+++ b/impl/src/test/resources/META-INF/test-unit.properties
@@ -1,3 +1,6 @@
+# If specification_base_url is specified, it will generate links to the appropriate section in the specification
+specification_base_url=https://docs.jboss.org/cdi/spec/1.2/cdi-spec.html
+
 # If fisheye_base_url is specified, it will generate links to the test class in fisheye
 #fisheye_base_url=http\://fisheye.jboss.org/browse/Weld/cdi-tck/trunk/impl/src/main/java
 


### PR DESCRIPTION
Hi @tremes ,

So I did pursue the migration of Hibernate Validator to string section ids as we discussed.

Here are 2 commits that I'd like to see integrated:
 * the first one allows to add a link from the coverage report to the spec. I think it's a nice addition. I was a bit worried about the name of the properties file which does not seem to match the scope of this new property. WDYT about it?
 * the second commit is more urgent. We use dash in our section ids and they are simply ignored in the `normalize` method. Would it be possible to take them into account and replace them with an underscore as I did it in my commit. It wouldn't change anything for people using underscores and I'm pretty sure people don't mix both. AFAICS the CDI tck uses underscores.

All in all, the first commit is just nice to have but the second is kinda important for us.

Thanks for your feedback.